### PR TITLE
Add timer when snapshot creation fails due to timeshift running

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ sudo make uninstall
 - [x] Ask to be included into official Timeshift package, [status pending](https://github.com/teejee2008/timeshift/issues/595).
 - [x] rsync /boot and /boot/efi to filesystem for more flexibility when restoring failed kernel updates (tested on Ubuntu 20.04 and Pop!_OS 20.04)
 - [x] Check and adapt [grub-btrfs](https://github.com/Antynea/grub-btrfs) for compatibility with Debian-based systems to automatically create menu entries into grub (tested on Ubuntu 20.04).
+- [x] Add timer when Timeshift is already running, allowing the user to close Timeshift and continue
 - [ ] Make rsync of /boot and /boot/efi dependent on btrfs only, provide "auto" model, i.e. check whether efi or legacy boot and then rsync into filesystem
 - [ ] Add prompt or pause if user wants to trigger timeshift-autosnap-apt or add optional timeout between snapshots
 - [ ] Provide better description of snapshots based on call to apt

--- a/timeshift-autosnap-apt
+++ b/timeshift-autosnap-apt
@@ -51,7 +51,17 @@ fi
 
 readonly SNAPSHOT_DESCRIPTION=$(get_property "snapshotDescription" "string" "{timeshift-autosnap-apt} {created before upgrade}")
 
-timeshift --create --comments "$SNAPSHOT_DESCRIPTION" || { echo "Unable to run timeshift-autosnap-apt! Please close Timeshift and try again. Script will now exit..." >&2; exit 1; }
+# This is a makeshift do-while loop, as per https://stackoverflow.com/a/16489942
+while true; do
+    SNAPSHOT_SUCCESSFUL=1
+    if ! timeshift --create --comments "$SNAPSHOT_DESCRIPTION"; then
+        echo "Unable to run timeshift-autosnap-apt! Please close Timeshift and try again. Script will exit in 30 seconds." >&2
+        read -t30 -n1 -p"Press any key  to try again. " || exit 1
+    else
+        SNAPSHOT_SUCCESSFUL=0
+    fi
+    [[ $SNAPSHOT_SUCCESSFUL -eq 1 ]] || break
+done
 
 if $(get_property "deleteSnapshots" "boolean" "true") ; then
     timeshift --list > $SNAPSHOTS_TO_DELETE


### PR DESCRIPTION
This enables the user to close Timeshift and try again in a 30-second time window.
 I hope you can understand my code, I sometimes write very non-self-explanatory code xD
I'll add some comments to explain how it works. I tested it with the `apt install`, `apt remove` and `apt purge` commands - it works as expected.